### PR TITLE
changes clocking_wizard version from 5.3 to 5.4 (for Vivado 2017.1 compatibility)

### DIFF
--- a/projects/4_frequency_counter/basic_red_pitaya_bd.tcl
+++ b/projects/4_frequency_counter/basic_red_pitaya_bd.tcl
@@ -77,7 +77,7 @@ endgroup
 
 # Add IP core: clocking_wizard
 startgroup
-create_bd_cell -type ip -vlnv xilinx.com:ip:clk_wiz:5.3 clk_wiz_0
+create_bd_cell -type ip -vlnv xilinx.com:ip:clk_wiz:5.4 clk_wiz_0
 set_property -dict [list CONFIG.PRIM_IN_FREQ.VALUE_SRC USER] [get_bd_cells clk_wiz_0]
 set_property -dict [list CONFIG.PRIM_IN_FREQ {125.000} CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {250.000} CONFIG.USE_RESET {false} CONFIG.CLKIN1_JITTER_PS {80.0} CONFIG.MMCM_DIVCLK_DIVIDE {1} CONFIG.MMCM_CLKFBOUT_MULT_F {8.000} CONFIG.MMCM_CLKIN1_PERIOD {8.0} CONFIG.MMCM_CLKOUT0_DIVIDE_F {4.000} CONFIG.CLKOUT1_JITTER {104.759} CONFIG.CLKOUT1_PHASE_ERROR {96.948}] [get_bd_cells clk_wiz_0]
 endgroup


### PR DESCRIPTION
The Block Design could not build on Vivado 2017.1  with the command "create_bd_cell -type ip -vlnv xilinx.com:ip:clk_wiz:5.3 clk_wiz_0" and was issuing an error. Changing the version of this clock_wizard block to 5.4 solves the issue.